### PR TITLE
Update /search endpoint to have ?

### DIFF
--- a/venues.go
+++ b/venues.go
@@ -28,7 +28,7 @@ func NewFSVenuesClient(id, secret string) FSClient {
 }
 
 func (c *FSClient) GetVenues(params map[string]string) (interface{}, error) {
-	return c.dispatchRequest(params, "/search/")
+	return c.dispatchRequest(params, "search?")
 }
 
 func (c *FSClient) GetCategories(params map[string]string) (interface{}, error) {


### PR DESCRIPTION
This pull request updates `GetVenues` to build the query params properly.  Before the update, urls like the following were being produced:

`https://api.foursquare.com/v2/venues//search/client_id=xxxxx&client_secret=xxxx&ll=34%2C-122&v=20131014`

that resulted in 400 errors.Afterwards, they look like

`https://api.foursquare.com/v2/venues/search?client_id=xxx&client_secret=xxxx&ll=37.769%2C-122.430&v=20131014`

and return 200's with data. 

Thanks for writing this package!
